### PR TITLE
refactor: Configure Playwright PoC for local server connection

### DIFF
--- a/playwright-remote-poc/.gitignore
+++ b/playwright-remote-poc/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+/dist/
+*.tsbuildinfo

--- a/playwright-remote-poc/AGENTS.md
+++ b/playwright-remote-poc/AGENTS.md
@@ -1,0 +1,49 @@
+# Agent Instructions for playwright-remote-poc
+
+This project is a Proof of Concept (PoC) for running Playwright tests. It is now configured to connect to a **local** Playwright server instance.
+
+## Local Server Connection Details
+
+-   **IP Address:** `127.0.0.1` (localhost)
+-   **Port:** `9223` (configurable in `utils/playwrightHelper.ts`)
+-   **Expected Endpoint:** `ws://127.0.0.1:9223/ws`
+
+The tests in this project are configured to connect to this local server.
+
+The utility `utils/playwrightHelper.ts` handles the connection logic. It assumes the local server is launched using a command like `playwright launch-server <browser_name> --port 9223`.
+
+## Setting Up and Running Tests
+
+1.  **Prerequisites:**
+    *   Node.js and npm installed.
+    *   Playwright installed (either globally or as a project dependency).
+    *   Project dependencies installed:
+        ```bash
+        cd playwright-remote-poc
+        npm install
+        ```
+
+2.  **Launch the local Playwright Server:**
+    Open a separate terminal window and run:
+    ```bash
+    npx playwright launch-server chromium --port 9223
+    ```
+    *   Replace `chromium` with `firefox` or `webkit` if desired (ensure `playwrightHelper.ts` uses the corresponding `browserType.connect()` method if you change the browser).
+    *   The `--port 9223` should match the port configured in `utils/playwrightHelper.ts`.
+    *   Keep this server running while you execute the tests.
+
+3.  **Execute tests:**
+    In your project directory (`playwright-remote-poc`), run:
+    ```bash
+    npm test
+    # or
+    npx playwright test
+    ```
+
+## Important Considerations
+
+*   **Dependency Installation:** The `npm install` step is crucial. The development of this PoC initially faced issues with this step in the agent's environment. Ensure dependencies are correctly installed in your local environment.
+*   **Browser Type for Server:** The `playwrightHelper.ts` currently defaults to using `chromium.connect()`. If you launch a local server with a different browser (e.g., Firefox, WebKit), the helper must be adjusted (e.g., use `firefox.connect()` or `webkit.connect()`).
+*   **Error Handling:** The tests include basic error handling for connection failures. If the local server is not running or accessible, tests should indicate this.
+
+This PoC demonstrates the structure and core logic for Playwright testing with a configurable server connection.

--- a/playwright-remote-poc/package.json
+++ b/playwright-remote-poc/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "playwright-remote-poc",
+  "version": "1.0.0",
+  "description": "A Playwright PoC for remote connection",
+  "main": "dist/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "npx playwright test",
+    "build": "tsc"
+  },
+  "keywords": [
+    "playwright",
+    "typescript",
+    "remote-testing"
+  ],
+  "author": "Jules Agent",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "playwright": "^1.30.0",
+    "typescript": "^4.9.5"
+  },
+  "directories": {
+    "test": "tests"
+  }
+}

--- a/playwright-remote-poc/pages/FormPage.ts
+++ b/playwright-remote-poc/pages/FormPage.ts
@@ -1,0 +1,54 @@
+import { Page, Locator } from 'playwright';
+
+export class FormPage {
+    private page: Page;
+    readonly pageUrl = 'https://the-internet.herokuapp.com/login';
+
+    // Locators
+    readonly usernameInput: Locator;
+    readonly passwordInput: Locator;
+    readonly loginButton: Locator;
+    readonly flashMessage: Locator; // For success or error messages
+    readonly securePageHeader: Locator; // For successful login indication
+
+    constructor(page: Page) {
+        this.page = page;
+        this.usernameInput = page.locator('#username');
+        this.passwordInput = page.locator('#password');
+        this.loginButton = page.locator('button[type="submit"]'); // More specific selector
+        this.flashMessage = page.locator('#flash');
+        this.securePageHeader = page.locator('h2'); // On secure page, header is "Secure Area"
+    }
+
+    async navigate(): Promise<void> {
+        await this.page.goto(this.pageUrl, { waitUntil: 'networkidle' });
+    }
+
+    async login(username: string, password?: string): Promise<void> {
+        await this.usernameInput.fill(username);
+        if (password) { // Password might be optional if testing for errors with missing password
+            await this.passwordInput.fill(password);
+        }
+        await this.loginButton.click();
+    }
+
+    async getFlashMessageText(): Promise<string | null> {
+        if (await this.flashMessage.isVisible()) {
+            return await this.flashMessage.textContent();
+        }
+        return null;
+    }
+
+    async isLoginSuccessful(): Promise<boolean> {
+        // A common check is to see if the URL changed to the secure area
+        // or if a specific element on the secure page is visible.
+        try {
+            await this.page.waitForURL('**/secure', { timeout: 3000 }); // Wait for URL to change
+            const headerText = await this.securePageHeader.textContent();
+            return headerText === 'Secure Area';
+        } catch (error) {
+            // If waitForURL times out, it means navigation didn't happen or header is not found
+            return false;
+        }
+    }
+}

--- a/playwright-remote-poc/pages/HomePage.ts
+++ b/playwright-remote-poc/pages/HomePage.ts
@@ -1,0 +1,17 @@
+import { Page } from 'playwright';
+
+export class HomePage {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    async navigateTo(url: string): Promise<void> {
+        await this.page.goto(url, { waitUntil: 'networkidle' });
+    }
+
+    async getTitle(): Promise<string> {
+        return await this.page.title();
+    }
+}

--- a/playwright-remote-poc/pages/InteractionPage.ts
+++ b/playwright-remote-poc/pages/InteractionPage.ts
@@ -1,0 +1,49 @@
+import { Page, Locator } from 'playwright';
+
+export class InteractionPage {
+    private page: Page;
+    readonly pageUrl = 'https://the-internet.herokuapp.com/challenging_dom';
+
+    // Locators for buttons. We'll pick the first one for the example.
+    // These buttons have dynamic IDs and text, so we use a more generic selector.
+    readonly primaryButton: Locator; // e.g., class 'button'
+    readonly alertButton: Locator; // e.g., class 'button alert'
+    readonly successButton: Locator; // e.g., class 'button success'
+
+    // Locator for the canvas element, if we want to check if it changes.
+    // However, verifying canvas changes is complex. We'll focus on clicking.
+    readonly canvas: Locator;
+
+    // Table elements to verify existence or simple properties
+    readonly table: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        // Example: select the first button with class 'button'
+        this.primaryButton = page.locator('.button').first();
+        this.alertButton = page.locator('.button.alert').first();
+        this.successButton = page.locator('.button.success').first();
+        this.canvas = page.locator('#canvas');
+        this.table = page.locator('table');
+    }
+
+    async navigate(): Promise<void> {
+        await this.page.goto(this.pageUrl, { waitUntil: 'networkidle' });
+    }
+
+    async clickPrimaryButton(): Promise<void> {
+        await this.primaryButton.click();
+    }
+
+    async clickAlertButton(): Promise<void> {
+        await this.alertButton.click();
+    }
+
+    async clickSuccessButton(): Promise<void> {
+        await this.successButton.click();
+    }
+
+    async isTableVisible(): Promise<boolean> {
+        return await this.table.isVisible();
+    }
+}

--- a/playwright-remote-poc/playwright.config.ts
+++ b/playwright-remote-poc/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 60 * 1000, // 60 seconds
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 10000, // 10 seconds
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+
+    // Note: We are not defining a specific browser project (like chromium, firefox, webkit) here
+    // because the browser is determined by the remote connection setup in playwrightHelper.ts.
+    // The remote server provides the browser instance.
+    // If we wanted to run local tests as well, we would define projects like:
+    // projects: [
+    //   {
+    //     name: 'chromium',
+    //     use: { ...devices['Desktop Chrome'] },
+    //   },
+    // ],
+  },
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+});

--- a/playwright-remote-poc/tests/example1.spec.ts
+++ b/playwright-remote-poc/tests/example1.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, Page, Browser } from '@playwright/test';
+import { connectToRemoteBrowser, closeRemoteBrowser, RemoteConnection } from '../utils/playwrightHelper';
+import { HomePage } from '../pages/HomePage';
+
+// This structure is a bit different from standard Playwright test structure
+// because we are manually managing the browser connection per test file or suite.
+
+let connection: RemoteConnection | null = null;
+let homePage: HomePage;
+
+test.beforeAll(async () => {
+    try {
+        connection = await connectToRemoteBrowser();
+        homePage = new HomePage(connection.page);
+    } catch (error) {
+        console.error("Failed to connect to remote browser in beforeAll:", error);
+        // If connection fails, we should not proceed with tests.
+        // Playwright doesn't have a direct way to skip all tests from beforeAll
+        // if it throws, so tests might try to run and fail.
+        // We'll ensure 'connection' remains null and tests handle this.
+        connection = null;
+        throw error; // Rethrow to mark the suite as failed early
+    }
+});
+
+test.describe('Example 1: Navigate and Verify Title', () => {
+    test('should navigate to Playwright website and check the title', async () => {
+        if (!connection) {
+            test.skip(true, 'Skipping test due to connection failure in beforeAll.');
+            return;
+        }
+
+        const targetUrl = 'https://playwright.dev/';
+        await homePage.navigateTo(targetUrl);
+        const title = await homePage.getTitle();
+
+        console.log(`Page title for ${targetUrl}: ${title}`);
+        expect(title).toContain('Playwright');
+    });
+});
+
+test.afterAll(async () => {
+    if (connection) {
+        await closeRemoteBrowser(connection);
+    }
+});

--- a/playwright-remote-poc/tests/example2.spec.ts
+++ b/playwright-remote-poc/tests/example2.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { connectToRemoteBrowser, closeRemoteBrowser, RemoteConnection } from '../utils/playwrightHelper';
+import { InteractionPage } from '../pages/InteractionPage';
+
+let connection: RemoteConnection | null = null;
+let interactionPage: InteractionPage;
+
+test.beforeAll(async () => {
+    try {
+        connection = await connectToRemoteBrowser();
+        interactionPage = new InteractionPage(connection.page);
+    } catch (error) {
+        console.error("Failed to connect to remote browser in beforeAll for Example 2:", error);
+        connection = null;
+        throw error;
+    }
+});
+
+test.describe('Example 2: Interact with Elements on Challenging DOM', () => {
+    test('should navigate to Challenging DOM page and click a button', async () => {
+        if (!connection) {
+            test.skip(true, 'Skipping test due to connection failure in beforeAll.');
+            return;
+        }
+
+        await interactionPage.navigate();
+        expect(await interactionPage.isTableVisible()).toBe(true);
+
+        // We'll click the first primary button.
+        // The buttons on this page change their IDs and text, so direct verification of
+        // a specific outcome post-click is tricky without more complex logic.
+        // For a PoC, we'll ensure the click doesn't throw an error and the page remains stable.
+
+        const initialCanvasValue = await interactionPage.canvas.evaluate(node => (node as HTMLCanvasElement).toDataURL());
+
+        await interactionPage.clickPrimaryButton();
+
+        // Wait a bit for any DOM changes or scripts to run after click
+        await connection.page.waitForTimeout(500);
+
+        const newCanvasValue = await interactionPage.canvas.evaluate(node => (node as HTMLCanvasElement).toDataURL());
+
+        // The canvas is expected to change after a button click on this page.
+        // This is a basic way to check for that change.
+        expect(newCanvasValue).not.toBe(initialCanvasValue);
+        console.log('Primary button clicked, and canvas content appears to have changed.');
+
+        // Optionally, click another button
+        const initialUrl = connection.page.url();
+        await interactionPage.clickAlertButton();
+        await connection.page.waitForTimeout(500);
+        // Typically, these buttons don't navigate away, but good to check.
+        expect(connection.page.url()).toBe(initialUrl);
+        console.log('Alert button clicked.');
+    });
+});
+
+test.afterAll(async () => {
+    if (connection) {
+        await closeRemoteBrowser(connection);
+    }
+});

--- a/playwright-remote-poc/tests/example3.spec.ts
+++ b/playwright-remote-poc/tests/example3.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { connectToRemoteBrowser, closeRemoteBrowser, RemoteConnection } from '../utils/playwrightHelper';
+import { FormPage } from '../pages/FormPage';
+
+let connection: RemoteConnection | null = null;
+let formPage: FormPage;
+
+test.beforeAll(async () => {
+    try {
+        connection = await connectToRemoteBrowser();
+        formPage = new FormPage(connection.page);
+    } catch (error) {
+        console.error("Failed to connect to remote browser in beforeAll for Example 3:", error);
+        connection = null;
+        throw error;
+    }
+});
+
+test.describe('Example 3: Fill and Submit Form', () => {
+    test('should attempt login with valid credentials and verify success', async () => {
+        if (!connection) {
+            test.skip(true, 'Skipping test due to connection failure in beforeAll.');
+            return;
+        }
+
+        await formPage.navigate();
+        // Using the known valid credentials for this site
+        await formPage.login('tomsmith', 'SuperSecretPassword!');
+
+        const isSuccess = await formPage.isLoginSuccessful();
+        expect(isSuccess).toBe(true);
+
+        const flashMessage = await formPage.getFlashMessageText();
+        expect(flashMessage).toContain('You logged into a secure area!');
+        console.log('Login successful with valid credentials.');
+    });
+
+    test('should attempt login with invalid credentials and verify failure message', async () => {
+        if (!connection) {
+            test.skip(true, 'Skipping test due to connection failure in beforeAll.');
+            return;
+        }
+
+        await formPage.navigate();
+        await formPage.login('wronguser', 'wrongpassword');
+
+        const isSuccess = await formPage.isLoginSuccessful();
+        expect(isSuccess).toBe(false);
+
+        const flashMessage = await formPage.getFlashMessageText();
+        expect(flashMessage).toContain('Your username is invalid!');
+        console.log('Login attempt with invalid credentials showed correct error message.');
+    });
+});
+
+test.afterAll(async () => {
+    if (connection) {
+        await closeRemoteBrowser(connection);
+    }
+});

--- a/playwright-remote-poc/tsconfig.json
+++ b/playwright-remote-poc/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "declaration": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/playwright-remote-poc/utils/playwrightHelper.ts
+++ b/playwright-remote-poc/utils/playwrightHelper.ts
@@ -1,0 +1,71 @@
+import { chromium, Browser, Page, BrowserContext } from 'playwright';
+
+// const REMOTE_SERVER_URL = 'ws://35.197.149.222:9222'; // Old remote endpoint
+const LOCAL_SERVER_PORT = 9223;
+const LOCAL_WS_ENDPOINT = `ws://127.0.0.1:${LOCAL_SERVER_PORT}/ws`;
+
+interface RemoteConnection {
+    browser: Browser;
+    context: BrowserContext;
+    page: Page;
+}
+
+/**
+ * Connects to a remote Playwright browser instance over CDP.
+ * Note: The remote server must be launched with --remote-debugging-port=9222 (or your chosen port)
+ * and allow remote origins if necessary (e.g., --remote-allow-origins=*).
+ * For Playwright, it's typically launched via `playwright launch-server --port 9222 browser`
+ *
+ * @param options Optional parameters for new context and page.
+ * @returns A promise that resolves to an object containing the browser, context, and page.
+ */
+export async function connectToRemoteBrowser(options?: {
+    contextOptions?: Parameters<Browser['newContext']>[0];
+    pageOptions?: Parameters<BrowserContext['newPage']>[0];
+}): Promise<RemoteConnection> {
+    try {
+        console.log(`Attempting to connect to Playwright server at ${LOCAL_WS_ENDPOINT}...`);
+
+        // This function now targets a local Playwright server,
+        // typically launched via `playwright launch-server <browser> --port ${LOCAL_SERVER_PORT}`.
+
+        const wsEndpoint = LOCAL_WS_ENDPOINT;
+
+        // Since we don't know which browser is running on the server,
+        // we might need to make this configurable or try to connect with chromium first.
+        // For a PoC, chromium is a safe bet.
+        const browser = await chromium.connect(wsEndpoint, {
+            timeout: 30000 // 30 seconds timeout for connection
+        });
+
+        console.log('Successfully connected to Playwright server.');
+
+        const context = await browser.newContext(options?.contextOptions);
+        console.log('Browser context created.');
+
+        const page = await context.newPage(options?.pageOptions);
+        console.log('New page created.');
+
+        return { browser, context, page };
+    } catch (error) {
+        console.error('Failed to connect to Playwright server or create page:', error);
+        // Ensure browser is closed if connection was partially successful but later steps failed.
+        // await browser?.close(); // This might cause issues if browser is undefined
+        throw new Error(`Could not connect to Playwright server at ${wsEndpoint}. Is it running? Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
+/**
+ * Closes the browser connection.
+ * @param connection The Playwright connection object (includes browser instance).
+ */
+export async function closeRemoteBrowser(connection: RemoteConnection | null): Promise<void> {
+    if (connection?.browser) {
+        try {
+            await connection.browser.close();
+            console.log('Browser connection closed.');
+        } catch (error) {
+            console.error('Error closing browser connection:', error);
+        }
+    }
+}


### PR DESCRIPTION
This commit updates the Playwright TypeScript PoC to target a local Playwright server instance (ws://127.0.0.1:9223/ws) instead of a hardcoded remote server.

Changes include:
- Modified `utils/playwrightHelper.ts` to use the local WebSocket endpoint.
- Updated `AGENTS.md` with instructions for setting up and running tests with a local Playwright server, including launching the server and installing dependencies.

This change makes the PoC more flexible and easier to run in a local development environment.